### PR TITLE
Add path indicator and clue token display to game header

### DIFF
--- a/web/css/game.css
+++ b/web/css/game.css
@@ -23,6 +23,34 @@
     letter-spacing: 0.2em;
 }
 
+.game-path-display {
+    font-family: var(--font-title);
+    font-size: 0.9rem;
+    color: var(--color-text);
+    letter-spacing: 0.15em;
+}
+
+.game-clue-tokens-wrap {
+    display: flex;
+    gap: 0.4rem;
+    align-items: center;
+}
+
+.clue-token {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.6rem;
+    height: 1.6rem;
+    border-radius: 50%;
+    background: #f5f0e8;
+    color: #1a1209;
+    font-family: var(--font-title);
+    font-size: 0.9rem;
+    font-weight: 700;
+    line-height: 1;
+}
+
 /* Chapter title area (section 0) */
 
 .chapter-title-area {

--- a/web/index.html
+++ b/web/index.html
@@ -102,9 +102,9 @@
         <!-- Game header bar -->
         <div class="game-header d-flex align-items-center justify-content-between px-3 py-2 flex-shrink-0">
             <button id="btn-game-back" class="btn btn-ghost-game">Back</button>
-            <div class="d-flex flex-column align-items-center gap-1">
-                <span id="game-time" class="game-time-display">TIME: 0</span>
+            <div class="d-flex align-items-center gap-3">
                 <span id="game-path-label" class="game-path-display d-none"></span>
+                <span id="game-time" class="game-time-display">TIME: 0</span>
                 <div  id="game-clue-tokens" class="game-clue-tokens-wrap d-none"></div>
             </div>
             <div class="d-flex gap-2">

--- a/web/index.html
+++ b/web/index.html
@@ -102,7 +102,11 @@
         <!-- Game header bar -->
         <div class="game-header d-flex align-items-center justify-content-between px-3 py-2 flex-shrink-0">
             <button id="btn-game-back" class="btn btn-ghost-game">Back</button>
-            <span id="game-time" class="game-time-display">TIME: 0</span>
+            <div class="d-flex flex-column align-items-center gap-1">
+                <span id="game-time" class="game-time-display">TIME: 0</span>
+                <span id="game-path-label" class="game-path-display d-none"></span>
+                <div  id="game-clue-tokens" class="game-clue-tokens-wrap d-none"></div>
+            </div>
             <div class="d-flex gap-2">
                 <button id="btn-settings-game" class="btn btn-ghost-game" title="Settings"><img src="data/ui/settings.png" class="settings-icon" alt="Settings"></button>
                 <button id="btn-might-open" class="btn btn-ghost-game" data-string-key="ui.might_decks">Might Decks</button>

--- a/web/js/game.js
+++ b/web/js/game.js
@@ -15,9 +15,9 @@
  *
  *   [STORAGE]       _load(), _save(), _chapterSave(), _getArr/_setArr, _getInt/_setInt, _getBool/_setBool
  *   [NAVIGATION]    getCurrentSectionNum(), setCurrentSectionNum(), removeCurrentSectionNum()
- *   [TIME]          manageTime(), _timePop(), getTime(), returnToNextPositionToken()
+ *   [TIME]          manageTime(), _timePop(), getTime(), returnToNextPositionToken(), getActivePath()
  *   [LOCATIONS]     getLocationsList(), removeLocation(), reAddLocation()
- *   [CLUES]         _addAndPopClues(), _removeAndUnPopClues()
+ *   [CLUES]         _addAndPopClues(), _removeAndUnPopClues(), getClueTokens()
  *   [DEEPWOOD]      _setupDeepwood(), _secondDeepwoodVisitRedirect(), _reAddDeepwoodIfBackingOut()
  *   [CAMPAIGN]      diedRestartChapter(), clearCampaign()
  *   [GAME_STATE]    GameState static object (campaign-level helpers)
@@ -371,6 +371,28 @@ class GameEngine {
         return this._getInt('nextPositionToken');
     }
 
+    // Returns 'A', 'B', or null.
+    // null means: not a two-path chapter, or player has not yet navigated far
+    // enough to determine a path (nextPositionToken still -1).
+    // Detection uses conditionalTimeTriggers: path B conditions are identified
+    // by whenTokenInRange with min > 0 (path B sections never start at 0).
+    getActivePath() {
+        const ctt = this.chapterData.conditionalTimeTriggers;
+        if (!ctt) return null;
+        const npt = this._getInt('nextPositionToken');
+        if (npt < 0) return null;
+        let hasPathBCondition = false;
+        for (const cond of Object.values(ctt)) {
+            if (!cond.whenTokenInRange) continue;
+            const [min, max] = cond.whenTokenInRange;
+            if (min <= 0) continue;
+            hasPathBCondition = true;
+            if (npt >= min && npt <= max) return 'B';
+            if (cond.orTokenIs && cond.orTokenIs.includes(npt)) return 'B';
+        }
+        return hasPathBCondition ? 'A' : null;
+    }
+
     //
     // ========================================================================
     //  [LOCATIONS]
@@ -478,6 +500,18 @@ class GameEngine {
             }
             this._setBool('clue2', false);
         }
+    }
+
+    // Returns an array of clue numbers (1 and/or 2) the player currently holds,
+    // in acquisition order. Empty array when the chapter has no clue mechanic
+    // or no clues have been found yet.
+    getClueTokens() {
+        const clues = this.chapterData.clue;
+        if (!clues || clues[0] === -1) return [];
+        const tokens = [];
+        if (this._getBool('clue1')) tokens.push(1);
+        if (this._getBool('clue2')) tokens.push(2);
+        return tokens;
     }
 
     //

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -13,7 +13,7 @@
  *   [GAME_STATE]        module-level variables
  *   [HOME]              home screen
  *   [CHAPTER_SELECT]    chapter select screen
- *   [GAME_SCREEN]       startChapter(), loadSection()
+ *   [GAME_SCREEN]       startChapter(), loadSection(), updatePathDisplay(), updateClueDisplay()
  *   [RENDER_PLATE]      renderPlate()
  *   [IMAGE_LIGHTBOX]    openImageLightbox()
  *   [RENDER_BUTTONS]    renderButtons()
@@ -401,6 +401,8 @@ function loadSection(goingBack) {
     // Time display
     const time = engine.getTime();
     document.getElementById('game-time').textContent = 'TIME: ' + time;
+    updatePathDisplay();
+    updateClueDisplay();
 
     // Chapter title (shown only on section 0 first visit)
     const titleArea = document.getElementById('chapter-title-area');
@@ -424,6 +426,36 @@ function loadSection(goingBack) {
 
     // Scroll content to top
     document.getElementById('game-content').scrollTop = 0;
+}
+
+function updatePathDisplay() {
+    const path = engine.getActivePath();
+    const el = document.getElementById('game-path-label');
+    if (path) {
+        el.textContent = S('ui.path_label').replace('%s', path);
+        el.dataset.stringKey = 'ui.path_label';
+        el.dataset.stringParam = path;
+        el.classList.remove('d-none');
+    } else {
+        el.classList.add('d-none');
+    }
+}
+
+function updateClueDisplay() {
+    const tokens = engine.getClueTokens();
+    const wrap = document.getElementById('game-clue-tokens');
+    wrap.innerHTML = '';
+    if (tokens.length === 0) {
+        wrap.classList.add('d-none');
+        return;
+    }
+    tokens.forEach(function(n) {
+        const tok = document.createElement('div');
+        tok.className = 'clue-token';
+        tok.textContent = n;
+        wrap.appendChild(tok);
+    });
+    wrap.classList.remove('d-none');
 }
 
 //

--- a/web/js/ui_strings.js
+++ b/web/js/ui_strings.js
@@ -63,6 +63,8 @@ STRINGS["en"] = Object.assign(STRINGS["en"] || {}, {
     "ui.lightbox_close":        "Click anywhere to close",
     "ui.open_github_issues":    "Open GitHub Issues",
     "ui.raw_json":              "Raw JSON",
+    // Path indicator (two-path chapters only)
+    "ui.path_label":            "PATH: %s",
     // Audio track label
     "ui.audio_label":           "Track %s / %s",
     "ui.audio":                 "Audio",
@@ -151,6 +153,7 @@ STRINGS["de"] = Object.assign(STRINGS["de"] || {}, {
     "ui.lightbox_close":        "Klicke irgendwo zum Schlie\u00dfen",
     "ui.open_github_issues":    "GitHub Issues \u00f6ffnen",
     "ui.raw_json":              "Roh-JSON",
+    "ui.path_label":            "PFAD: %s",
     "ui.audio_label":           "Spur %s / %s",
     "ui.audio":                 "Audio",
     "ui.no_saved_progress":       "Kein gespeicherter Fortschritt.",
@@ -236,6 +239,7 @@ STRINGS["it"] = Object.assign(STRINGS["it"] || {}, {
     "ui.lightbox_close":        "Clicca ovunque per chiudere",
     "ui.open_github_issues":    "Apri le Segnalazioni GitHub",
     "ui.raw_json":              "JSON Grezzo",
+    "ui.path_label":            "PERCORSO: %s",
     "ui.audio_label":           "Traccia %s / %s",
     "ui.audio":                 "Audio",
     "ui.no_saved_progress":       "Nessun progresso salvato.",
@@ -321,6 +325,7 @@ STRINGS["fr"] = Object.assign(STRINGS["fr"] || {}, {
     "ui.lightbox_close":        "Cliquez n\u2019importe o\u00f9 pour fermer",
     "ui.open_github_issues":    "Ouvrir les Issues GitHub",
     "ui.raw_json":              "JSON Brut",
+    "ui.path_label":            "CHEMIN: %s",
     "ui.audio_label":           "Piste %s / %s",
     "ui.audio":                 "Audio",
     "ui.no_saved_progress":       "Aucune progression sauvegard\u00e9e.",


### PR DESCRIPTION
Two new status indicators appear near the TIME display during gameplay:

- Path indicator: shows PATH: A or PATH: B for the 5 two-path chapters (2, 5, 7, 9, 15). Derives the active path from the existing conditionalTimeTriggers data - path B conditions use whenTokenInRange with min > 0, which is a reliable signal without any new chapter data. Hidden on non-two-path chapters and before the player has navigated far enough to set a nextPositionToken. Translatable via ui.path_label (en/de/fr/it); carries data-string-key/param so language switches update it automatically.

- Clue tokens: white circle tokens labeled 1 and 2, shown whenever the player holds clue1 or clue2 in a chapter that uses the clue mechanic. Hidden otherwise.

New public GameEngine methods: getActivePath(), getClueTokens().