### PR TITLE
Fix setup on Windows: gdown API compat and Docker volume mounts

### DIFF
--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -99,6 +99,17 @@ def verify_sha256(path, expected):
 # Steps
 # ---------------------------------------------------------------------------
 
+def _gdown_download(gdown, url, dest_path):
+    """Download from Google Drive, handling API differences across gdown versions.
+
+    The fuzzy= parameter was added in gdown 4.4.0 and dropped in 5.x.
+    """
+    try:
+        return gdown.download(url, dest_path, quiet=False, fuzzy=True)
+    except TypeError:
+        return gdown.download(url, dest_path, quiet=False)
+
+
 def step_download(dest_path):
     banner("Download APK")
     gdown = ensure_gdown()
@@ -108,7 +119,7 @@ def step_download(dest_path):
     for i, url in enumerate(APK_DRIVE_URLS, 1):
         print(f"  [{i}/{len(APK_DRIVE_URLS)}] {url}")
         try:
-            output = gdown.download(url, dest_path, quiet=False, fuzzy=True)
+            output = _gdown_download(gdown, url, dest_path)
         except Exception as e:
             print(f"  Failed: {e}")
             output = None
@@ -169,7 +180,7 @@ def step_download_german():
     for i, url in enumerate(APK_DE_DRIVE_URLS, 1):
         print(f"  [{i}/{len(APK_DE_DRIVE_URLS)}] {url}")
         try:
-            output = gdown.download(url, CACHED_APK_DE, quiet=False, fuzzy=True)
+            output = _gdown_download(gdown, url, CACHED_APK_DE)
         except Exception as e:
             print(f"  Failed: {e}")
             output = None

--- a/setup.sh
+++ b/setup.sh
@@ -47,12 +47,27 @@ docker build -t oathsworn-setup -f "$SCRIPT_DIR/Dockerfile" "$SCRIPT_DIR"
 
 echo ""
 echo "Running setup..."
+
+# On Windows Git Bash (MINGW), MSYS path translation mangles Docker volume
+# mount arguments, silently breaking bind mounts. Detect this environment,
+# convert host paths to Windows format, and disable path translation so the
+# container-side paths are passed through unchanged.
+# The :z SELinux relabeling flag is Linux-only and unsupported on Windows.
+if [[ "$(uname -s)" == MINGW* ]] || [[ "$(uname -s)" == MSYS* ]]; then
+    DATA_MOUNT="$(cygpath -m "$OUTPUT_DIR/data"):/repo/web/data"
+    CACHE_MOUNT="$(cygpath -m "$CACHE_DIR"):/cache"
+    export MSYS_NO_PATHCONV=1
+else
+    DATA_MOUNT="$OUTPUT_DIR/data:/repo/web/data:z"
+    CACHE_MOUNT="$CACHE_DIR:/cache:z"
+fi
+
 docker run --rm \
     -e HOST_UID="$(id -u)" \
     -e HOST_GID="$(id -g)" \
     -e INCLUDE_GERMAN_LANG="${INCLUDE_GERMAN_LANG:-}" \
-    -v "$OUTPUT_DIR/data:/repo/web/data:z" \
-    -v "$CACHE_DIR:/cache:z" \
+    -v "$DATA_MOUNT" \
+    -v "$CACHE_MOUNT" \
     oathsworn-setup
 
 echo ""


### PR DESCRIPTION
Two bugs affecting Windows users:

1. gdown 5.x dropped the fuzzy= parameter, causing "unexpected keyword argument 'fuzzy'" on fresh installs. Add _gdown_download() helper that tries fuzzy=True and falls back gracefully on TypeError.

2. Running setup.sh from Git Bash on Windows silently broke Docker bind mounts via MINGW path translation mangling the container-side volume paths. The container ran and passed the SHA check against its own ephemeral copy of the APK, but the host never received any output. Fix by detecting MINGW, converting host paths via cygpath, setting MSYS_NO_PATHCONV=1, and dropping the :z SELinux flag unsupported on Windows Docker Desktop.